### PR TITLE
add support for useragent

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@ Weeb.sh handler
 **Kind**: global class  
 
 * [Handler](#Handler)
-    * [new Handler(key, [keyType])](#new_Handler_new)
+    * [new Handler(key, [keyType], [userAgent])](#new_Handler_new)
     * [.getTags([hidden])](#Handler+getTags) ⇒ <code>Promise.&lt;Array.&lt;String&gt;&gt;</code>
     * [.getTypes([hidden])](#Handler+getTypes) ⇒ <code>Promise.&lt;Array.&lt;String&gt;&gt;</code>
     * [.getInfo()](#Handler+getInfo) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -16,12 +16,13 @@ Weeb.sh handler
 
 <a name="new_Handler_new"></a>
 
-### new Handler(key, [keyType])
+### new Handler(key, [keyType], [userAgent])
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | key | <code>String</code> |  | your API key for weeb.sh |
 | [keyType] | <code>String</code> | <code>&#x27;Bearer&#x27;</code> | Type of key you're using. Either 'Bearer' or 'Wolke' |
+| [userAgent] | <code>String</code> | <code>&#x27;Wolken/VERSION&#x27;</code> | The User-Agent to use for requests. Should be in the format `BotName/Version` or `BotName/Version/environment` |
 
 <a name="Handler+getTags"></a>
 

--- a/lib/Handler.js
+++ b/lib/Handler.js
@@ -15,12 +15,13 @@ const {BASE_URL, ENDPOINTS, FILETYPES, KEY_TYPES} = require('./Constants');
  * @param {String} [keyType='Bearer'] Type of key you're using. Either 'Bearer' or 'Wolke'
  */
 class Handler {
-    constructor(key, keyType='Bearer') {
+    constructor(key, keyType='Bearer', userAgent) {
         if (typeof key !== 'string') throw new TypeError('key is not a string.');
         if (typeof keyType !== 'string') throw new TypeError('keyType is not a string.');
         if (!KEY_TYPES.includes(keyType)) throw new Error('keyType must either be "Bearer" or "Wolke".');
 
         this.key = `${keyType} ${key}`;
+        this.userAgent = userAgent;
     }
 
     /**
@@ -34,7 +35,7 @@ class Handler {
             if (typeof hidden !== 'boolean') reject(new TypeError('hidden is not a boolean.'));
 
             https.request(Object.assign(url.parse(BASE_URL + ENDPOINTS.TAGS), {
-                headers: {Authorization: this.key}
+                headers: {Authorization: this.key, 'User-Agent': this.userAgent}
             }), res => {
                 let chunked = '';
 
@@ -66,7 +67,7 @@ class Handler {
             if (typeof hidden !== 'boolean') reject(new TypeError('hidden is not a boolean.'));
 
             https.request(Object.assign(url.parse(BASE_URL + ENDPOINTS.TYPES), {
-                headers: {Authorization: this.key}
+                headers: {Authorization: this.key, 'User-Agent': this.userAgent}
             }), res => {
                 let chunked = '';
 
@@ -95,7 +96,7 @@ class Handler {
     getInfo() {
         return new Promise((resolve, reject) => {
             https.request(Object.assign(url.parse(BASE_URL + ENDPOINTS.INFO), {
-                headers: {Authorization: this.key}
+                headers: {Authorization: this.key, 'User-Agent': this.userAgent}
             }), res => {
                 let chunked = '';
 
@@ -146,7 +147,7 @@ class Handler {
             if (options.filetype) query += `&filetype=${options.filetype}`;
 
             https.request(Object.assign(url.parse(BASE_URL + ENDPOINTS.RANDOM + query), {
-                headers: {Authorization: this.key}
+                headers: {Authorization: this.key, 'User-Agent': this.userAgent}
             }), res => {
                 let chunked = '';
                 

--- a/lib/Handler.js
+++ b/lib/Handler.js
@@ -6,7 +6,8 @@
 
 const https = require('https');
 const url = require('url');
-const {BASE_URL, ENDPOINTS, FILETYPES, KEY_TYPES} = require('./Constants');
+const { BASE_URL, ENDPOINTS, FILETYPES, KEY_TYPES } = require('./Constants');
+const { version } = require('../package.json');
 
 /**
  * Weeb.sh handler
@@ -15,10 +16,11 @@ const {BASE_URL, ENDPOINTS, FILETYPES, KEY_TYPES} = require('./Constants');
  * @param {String} [keyType='Bearer'] Type of key you're using. Either 'Bearer' or 'Wolke'
  */
 class Handler {
-    constructor(key, keyType='Bearer', userAgent) {
+    constructor(key, keyType='Bearer', userAgent = 'Wolken/' + version) {
         if (typeof key !== 'string') throw new TypeError('key is not a string.');
         if (typeof keyType !== 'string') throw new TypeError('keyType is not a string.');
         if (!KEY_TYPES.includes(keyType)) throw new Error('keyType must either be "Bearer" or "Wolke".');
+        if (typeof userAgent !== 'string') throw new TypeError('userAgent is not a string.');
 
         this.key = `${keyType} ${key}`;
         this.userAgent = userAgent;


### PR DESCRIPTION
Point 5 of the "Getting Started" channel states the following:

>When calling our API make sure to set a User-Agent HTTP Header in the following formats: `BotName/Version` or alternatively `BotName/Version/environment`
>Example:`Yuudachi/1.0.0` or `Yuudachi/1.0.0/beta` (What you set for version and environment is fully up to you, as long as the name is set correctly)
>This helps us to identify issues a lot better.

This PR adds an argument into the Handler constructor which allows a user to provide a custom user-agent for request headers.